### PR TITLE
Use wasm-pack new to setup template instead of cargo generate

### DIFF
--- a/src/game-of-life/hello-world.md
+++ b/src/game-of-life/hello-world.md
@@ -13,14 +13,7 @@ build, integrate, and package your code for the Web.
 Clone the project template with this command:
 
 ```text
-cargo generate --git https://github.com/rustwasm/wasm-pack-template
-```
-
-This should prompt you for the new project's name. We will use
-**"wasm-game-of-life"**.
-
-```text
-wasm-game-of-life
+wasm-pack new wasm-game-of-life
 ```
 
 ## What's Inside


### PR DESCRIPTION
### Summary
This PR updates the steps used to generate the template to use `wasm-pack new {project-name}` instead. This is cleaner and more concise and could reduce reliance on extra setup dependencies that could break over time.

<!-- if applicable, mark this PR as fixing an open issue -->
Fixes #214

[contributing]: https://github.com/rustwasm/book/blob/master/CONTRIBUTING.md
[open-prs]: https://github.com/rustwasm/book/pulls
